### PR TITLE
feat: add .NET 10.0 support and update CI/CD pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,23 @@ jobs:
           dotnet-version: |
             8.0.x
 
+      - name: Install .NET SDK 9.0.x
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            9.0.x
+
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
+
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: login
+        if: matrix.os == 'windows-latest' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        with:
+          user: ${{secrets.NUGET_USER}}
 
       - name: Run Cake script
         uses: cake-build/cake-action@v3
@@ -44,7 +57,7 @@ jobs:
           NuGetReportSettings_WorkspaceId: ${{ secrets.NUGETREPORTSETTINGS_WORKSPACEID }}
           GH_PACKAGES_NUGET_SOURCE: ${{ secrets.GH_PACKAGES_NUGET_SOURCE }}
           NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
-          NUGET_APIKEY: ${{ secrets.NUGET_APIKEY }}
+          NUGET_APIKEY: ${{steps.login.outputs.NUGET_API_KEY}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           cake-version: tool-manifest

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "latestMinor",
-    "version": "9.0.305"
+    "rollForward": "latestFeature",
+    "version": "10.0.100-rc.1.25451.107"
   }
 }

--- a/src/Devlead.Console/Devlead.Console.csproj
+++ b/src/Devlead.Console/Devlead.Console.csproj
@@ -2,7 +2,7 @@
   <Import Project="Devlead.Console.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon/devlead.console.png</PackageIcon>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,12 +1,26 @@
 <Project>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" VersionOverride="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="8.0.1" />
+    <PackageReference Include="System.Text.Json" VersionOverride="8.0.6" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" VersionOverride="10.0.0-rc.1.25451.107" />
+    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="10.0.0-rc.1.25451.107" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="10.0.0-rc.1.25451.107" />
+    <PackageReference Include="System.Text.Json" VersionOverride="10.0.0-rc.1.25451.107" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Spectre.Console.Cli" />
     <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" />
-    <PackageReference Include="System.Linq.Async" />
+    <PackageReference Include="System.Linq.Async" Condition="'$(TargetFramework)' != 'net10.0'" />
     <PackageReference Include="Spectre.Console.Analyzer" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 </Project> 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
+    <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
@@ -18,11 +18,11 @@
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0" />
-    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.13.0" />
+    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.14.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.51.1" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.51.1" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
     <PackageVersion Include="System.Text.Json" Version="9.0.9" />
-    <PackageVersion Include="Verify.NUnit" Version="30.11.0" />
+    <PackageVersion Include="Verify.NUnit" Version="30.12.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Add .NET 10.0 target framework support
- Update global.json to use .NET 10.0 RC with latestFeature rollForward
- Implement OIDC-based NuGet authentication in GitHub Actions
- Add .NET 9.0.x SDK installation step in CI
- Enable central package version overrides for framework-specific dependencies
- Update Spectre.Console.Cli.Extensions.DependencyInjection to 0.14.0
- Update Verify.NUnit to 30.12.0
- Configure framework-specific package version overrides for .NET 8.0/9.0/10.0