### PR TITLE
Update package versions and remove SourceLink configuration

### DIFF
--- a/src/Devlead.Console/Devlead.Console.props
+++ b/src/Devlead.Console/Devlead.Console.props
@@ -5,20 +5,4 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU1510</NoWarn>
   </PropertyGroup>
-
-  <Choose>
-    <When Condition="'$(CentralPackageVersionOverrideEnabled)' != 'false'">
-      <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" VersionOverride="8.0.0" Condition="'$(AzureRepos)' != 'true'" />
-        <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" PrivateAssets="all" VersionOverride="8.0.0" Condition="'$(AzureRepos)' == 'true'" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" Condition="'$(AzureRepos)' != 'true'" />
-        <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" PrivateAssets="all" Condition="'$(AzureRepos)' == 'true'" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,14 +13,14 @@
   
   <!-- net9.0 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" VersionOverride="9.0.11" Pack="false" />
-    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" VersionOverride="9.0.12" Pack="false" />
+    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.12" />
     
-    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="9.0.11" Pack="false" />
-    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="9.0.12" Pack="false" />
+    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging" Version="9.0.12" />
     
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="9.0.11" Pack="false" />
-    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging.Console" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="9.0.12" Pack="false" />
+    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging.Console" Version="9.0.12" />
   </ItemGroup>
 
   <!-- net10.0 -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,17 +6,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Devlead.Testing.MockHttp" Version="2025.12.16.528" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.1" />
+    <PackageVersion Include="Devlead.Testing.MockHttp" Version="2026.1.14.568" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="NuGetizer" Version="1.4.6" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0" />
-    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.21.0" />
+    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.22.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.54.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />


### PR DESCRIPTION
- Remove Microsoft.SourceLink package references from Devlead.Console.props (GitHub and AzureRepos variants with conditional logic)

- Update Microsoft.Extensions.* packages
  - net9.0: 9.0.11 → 9.0.12
  - net10.0: 10.0.1 → 10.0.2

- Update other dependencies
  - Devlead.Testing.MockHttp: 2025.12.16.528 → 2026.1.14.568
  - Spectre.Console.Cli.Extensions.DependencyInjection: 0.21.0 → 0.22.0