### PR TITLE
Remove unused path JSON converters and update dependencies

### DIFF
--- a/build/helpers.cs
+++ b/build/helpers.cs
@@ -37,25 +37,3 @@ public static partial class CakeTaskBuilderExtensions
     }
 
 }
-
-public class FilePathJsonConverter : PathJsonConverter<FilePath>
-{
-    protected override FilePath ConvertFromString(string value) => FilePath.FromString(value);
-}
-
-public abstract class PathJsonConverter<TPath> : System.Text.Json.Serialization.JsonConverter<TPath> where TPath : Cake.Core.IO.Path
-{
-    public override TPath Read(ref System.Text.Json.Utf8JsonReader reader, Type typeToConvert, System.Text.Json.JsonSerializerOptions options)
-    {
-        var value = reader.GetString();
-
-        return value is null ? null : ConvertFromString(value);
-    }
-
-    public override void Write(System.Text.Json.Utf8JsonWriter writer, TPath value, System.Text.Json.JsonSerializerOptions options)
-    {
-        writer.WriteStringValue(value.FullPath);
-    }
-
-    protected abstract TPath ConvertFromString(string value);
-}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "10.0.102"
+    "version": "10.0.103"
   }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,14 +13,14 @@
   
   <!-- net9.0 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" VersionOverride="9.0.12" Pack="false" />
-    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.12" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" VersionOverride="9.0.13" Pack="false" />
+    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.13" />
     
-    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="9.0.12" Pack="false" />
-    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging" Version="9.0.12" />
+    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="9.0.13" Pack="false" />
+    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging" Version="9.0.13" />
     
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="9.0.12" Pack="false" />
-    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging.Console" Version="9.0.12" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="9.0.13" Pack="false" />
+    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging.Console" Version="9.0.13" />
   </ItemGroup>
 
   <!-- net10.0 -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,20 +6,20 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Devlead.Testing.MockHttp" Version="2026.1.14.568" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.2" />
+    <PackageVersion Include="Devlead.Testing.MockHttp" Version="2026.2.11.605" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="NuGetizer" Version="1.4.7" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0" />
-    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.22.0" />
+    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.23.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.54.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
-    <PackageVersion Include="Verify.NUnit" Version="31.12.3" />
+    <PackageVersion Include="Verify.NUnit" Version="31.12.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Remove FilePathJsonConverter and PathJsonConverter from build/helpers.cs (no longer used)

- Bump .NET SDK in global.json: 10.0.102 → 10.0.103

- Update Microsoft.Extensions.* packages
  - net9.0: 9.0.12 → 9.0.13
  - net10.0: 10.0.2 → 10.0.3

- Update other packages
  - Devlead.Testing.MockHttp: 2026.1.14.568 → 2026.2.11.605
  - NuGetizer: 1.4.6 → 1.4.7
  - Spectre.Console.Cli.Extensions.DependencyInjection: 0.22.0 → 0.23.0
  - Verify.NUnit: 31.12.3 → 31.12.4