### PR TITLE
chore(deps): bump Spectre.Console to 0.55 & Spectre.Console.Cli.Extensions.DependencyInjection to 0.24.0

### DIFF
--- a/src/Devlead.Console.Integration.Test/Commands/TestCommand.cs
+++ b/src/Devlead.Console.Integration.Test/Commands/TestCommand.cs
@@ -1,9 +1,9 @@
-﻿
+
 namespace Devlead.Console.Integration.Test.Commands;
 
 public class TestCommand(TestService testService) : Command<TestSettings>
 {
-    public override int Execute(CommandContext context, TestSettings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, TestSettings settings, CancellationToken cancellationToken)
     {
         if (settings.ThrowError)
         {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,9 +16,9 @@
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0" />
-    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.23.0" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
-    <PackageVersion Include="Spectre.Console.Testing" Version="0.54.0" />
+    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.24.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
+    <PackageVersion Include="Spectre.Console.Testing" Version="0.55.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <PackageVersion Include="Verify.NUnit" Version="31.15.0" />
   </ItemGroup>


### PR DESCRIPTION
- Spectre.Console.Cli 0.53.1 → 0.55.0
- Spectre.Console.Testing 0.54.0 → 0.55.0
- Spectre.Console.Cli.Extensions.DependencyInjection 0.23.0 → 0.24.0
- Make TestCommand.Execute protected override (API change in Spectre.Console.Cli)