### PR TITLE
chore(deps): align package versions and bump central dependencies

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,13 +14,13 @@
   <!-- net9.0 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" VersionOverride="9.0.16" Pack="false" />
-    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.14" />
+    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.16" />
     
     <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="9.0.16" Pack="false" />
-    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging" Version="9.0.14" />
+    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging" Version="9.0.16" />
     
     <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="9.0.16" Pack="false" />
-    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging.Console" Version="9.0.14" />
+    <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging.Console" Version="9.0.16" />
   </ItemGroup>
 
   <!-- net10.0 -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,17 +6,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="Devlead.Testing.MockHttp" Version="2026.2.11.605" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageVersion Include="Devlead.Testing.MockHttp" Version="2026.5.15.777" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="NuGetizer" Version="1.4.7" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.13.0" />
     <PackageVersion Include="NUnit" Version="4.6.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0" />
-    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.24.0" />
+    <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.25.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.55.2" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />


### PR DESCRIPTION
- Sync net9.0 PackageFile versions (9.0.14 → 9.0.16) with PackageReference VersionOverride for Microsoft.Extensions.Configuration.EnvironmentVariables, Microsoft.Extensions.Logging, and Microsoft.Extensions.Logging.Console.
- Bump Microsoft.Extensions.* central versions 10.0.5 → 10.0.8.
- Bump Devlead.Testing.MockHttp 2026.2.11.605 → 2026.5.15.777.
- Bump Spectre.Console.Cli.Extensions.DependencyInjection 0.24.0 → 0.25.0.